### PR TITLE
Feature/34 verify blob timestamp

### DIFF
--- a/src/Altinn.FileScan.Functions/Clients/FileScanClient.cs
+++ b/src/Altinn.FileScan.Functions/Clients/FileScanClient.cs
@@ -19,7 +19,7 @@ namespace Altinn.FileScan.Functions.Clients
     {
         private readonly HttpClient _client;
         private readonly IAccessTokenGenerator _accessTokenGenerator;
-        private readonly IKeyVaultService _keyVaultService;
+        private readonly IKeyVaultService _keyVaultService; 
         private readonly KeyVaultSettings _keyVaultSettings;
         private readonly ILogger<IFileScanClient> _logger;
 

--- a/src/Altinn.FileScan/Models/BlobPropertyModel.cs
+++ b/src/Altinn.FileScan/Models/BlobPropertyModel.cs
@@ -1,0 +1,13 @@
+﻿namespace Altinn.FileScan.Models
+{
+    /// <summary>
+    /// Model type containing selected properties from Azure BlobProperties type
+    /// </summary>
+    public class BlobPropertyModel
+    {
+        /// <summary>
+        /// Gets or sets when the blob was last modified
+        /// </summary>
+        public DateTimeOffset LastModified { get; set; }
+    }
+}

--- a/src/Altinn.FileScan/Models/DataElementScanRequest.cs
+++ b/src/Altinn.FileScan/Models/DataElementScanRequest.cs
@@ -24,6 +24,11 @@
         public string Filename { get; set; }
 
         /// <summary>
+        /// Gets or sets the time when blob was saved.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
         /// Gets or sets the path to blob storage.
         /// </summary>
         public string BlobStoragePath { get; set; }

--- a/src/Altinn.FileScan/Repository/AppOwnerBlobRepository.cs
+++ b/src/Altinn.FileScan/Repository/AppOwnerBlobRepository.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.FileScan.Repository.Interfaces;
+﻿using Altinn.FileScan.Models;
+using Altinn.FileScan.Repository.Interfaces;
 
 using Azure.Storage.Blobs.Models;
 
@@ -29,12 +30,12 @@ namespace Altinn.FileScan.Repository
         }
 
         /// <inheritdoc/>
-        public async Task<BlobProperties> GetBlobProperties(string org, string blobPath)
+        public async Task<BlobPropertyModel> GetBlobProperties(string org, string blobPath)
         {
             var containerClient = await _containerClientProvider.GetBlobContainerClient(org);
             var blobClient = containerClient.GetBlobClient(blobPath);
             Azure.Response<BlobProperties> response = await blobClient.GetPropertiesAsync();
-            return response.Value;
+            return new BlobPropertyModel { LastModified = response.Value.LastModified };
         }
     }
 }

--- a/src/Altinn.FileScan/Repository/AppOwnerBlobRepository.cs
+++ b/src/Altinn.FileScan/Repository/AppOwnerBlobRepository.cs
@@ -27,5 +27,14 @@ namespace Altinn.FileScan.Repository
             Azure.Response<BlobDownloadInfo> response = await blobClient.DownloadAsync();
             return response.Value.Content;
         }
+
+        /// <inheritdoc/>
+        public async Task<BlobProperties> GetBlobProperties(string org, string blobPath)
+        {
+            var containerClient = await _containerClientProvider.GetBlobContainerClient(org);
+            var blobClient = containerClient.GetBlobClient(blobPath);
+            Azure.Response<BlobProperties> response = await blobClient.GetPropertiesAsync();
+            return response.Value;
+        }
     }
 }

--- a/src/Altinn.FileScan/Repository/Interfaces/IAppOwnerBlob.cs
+++ b/src/Altinn.FileScan/Repository/Interfaces/IAppOwnerBlob.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.FileScan.Repository.Interfaces
+﻿using Azure.Storage.Blobs.Models;
+
+namespace Altinn.FileScan.Repository.Interfaces
 {
     /// <summary>
     /// Interface containing all repository actions for an Altinn app owner Azure blob repository
@@ -12,5 +14,13 @@
         /// <param name="blobPath">Full path to the blob within a storage account</param>
         /// <returns>The blob as a stream</returns>W
         public Task<Stream> GetBlob(string org, string blobPath);
+
+        /// <summary>
+        /// Retrieves the blob metadata as stored by Blob Storage
+        /// </summary>
+        /// <param name="org">The short name of the organisation</param>
+        /// <param name="blobPath">Full path to the blob within a storage account</param>
+        /// <returns>Blob properties object</returns>
+        public Task<BlobProperties> GetBlobProperties(string org, string blobPath);
     }
 }

--- a/src/Altinn.FileScan/Repository/Interfaces/IAppOwnerBlob.cs
+++ b/src/Altinn.FileScan/Repository/Interfaces/IAppOwnerBlob.cs
@@ -1,5 +1,4 @@
 ﻿using Altinn.FileScan.Models;
-using Azure.Storage.Blobs.Models;
 
 namespace Altinn.FileScan.Repository.Interfaces
 {

--- a/src/Altinn.FileScan/Repository/Interfaces/IAppOwnerBlob.cs
+++ b/src/Altinn.FileScan/Repository/Interfaces/IAppOwnerBlob.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Storage.Blobs.Models;
+﻿using Altinn.FileScan.Models;
+using Azure.Storage.Blobs.Models;
 
 namespace Altinn.FileScan.Repository.Interfaces
 {
@@ -21,6 +22,6 @@ namespace Altinn.FileScan.Repository.Interfaces
         /// <param name="org">The short name of the organisation</param>
         /// <param name="blobPath">Full path to the blob within a storage account</param>
         /// <returns>Blob properties object</returns>
-        public Task<BlobProperties> GetBlobProperties(string org, string blobPath);
+        public Task<BlobPropertyModel> GetBlobProperties(string org, string blobPath);
     }
 }

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -39,9 +39,10 @@ namespace Altinn.FileScan.Services
                 if (blobProps.LastModified != scanRequest.Timestamp)
                 {
                     _logger.LogError(
-                        "Scan request timestamp != blob last modified timestamp. Instance Id: {instanceId}, DataElementId: {dataElementId}", 
+                        "Scan request timestamp != blob last modified timestamp, scan request aborted. Instance Id: {instanceId}, DataElementId: {dataElementId}, timestamp diff: {timeDiff} seconds", 
                         scanRequest.InstanceId, 
-                        scanRequest.DataElementId);
+                        scanRequest.DataElementId,
+                        scanRequest.Timestamp.Subtract(blobProps.LastModified).TotalSeconds);
                     return;
                 }
 

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -34,6 +34,17 @@ namespace Altinn.FileScan.Services
         {
             try
             {
+                var blobProps = await _repository.GetBlobProperties(scanRequest.Org, scanRequest.BlobStoragePath);
+
+                if (blobProps.LastModified != scanRequest.Timestamp)
+                {
+                    _logger.LogError(
+                        "Scan request timestamp != blob last modified timestamp. Instance Id: {instanceId}, DataElementId: {dataElementId}", 
+                        scanRequest.InstanceId, 
+                        scanRequest.DataElementId);
+                    return;
+                }
+
                 var stream = await _repository.GetBlob(scanRequest.Org, scanRequest.BlobStoragePath);
 
                 var filename = string.IsNullOrEmpty(scanRequest.Filename) ? $"{scanRequest.DataElementId}.txt" : scanRequest.Filename;

--- a/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
+++ b/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-
-using Altinn.FileScan.Clients;
 using Altinn.FileScan.Clients.Interfaces;
 using Altinn.FileScan.Exceptions;
 using Altinn.FileScan.Models;
@@ -13,24 +11,24 @@ using Altinn.FileScan.Services;
 using Altinn.FileScan.Services.Interfaces;
 using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
-
-using Castle.Core.Logging;
-
 using Microsoft.Extensions.Logging;
-
 using Moq;
-
 using Xunit;
 
 namespace Altinn.FileScan.Tests.TestingServices
 {
     public class DataElementServiceTests
     {
+        private static DateTimeOffset requestTimestamp = new DateTimeOffset(2023, 1, 10, 8, 0, 0, new TimeSpan(0, 0, 0));
+        private static DateTimeOffset matchingTimestamp = new DateTimeOffset(2023, 1, 10, 8, 0, 0, new TimeSpan(0, 0, 0));
+        private static DateTimeOffset nonMatchingTimestamp = new DateTimeOffset(2023, 1, 10, 8, 30, 0, new TimeSpan(0, 0, 0));
+
         private DataElementScanRequest _defaultDataElementScanRequest = new DataElementScanRequest
         {
             BlobStoragePath = "blobstoragePath/org/attachment.pdf",
             DataElementId = "dataElementId",
             InstanceId = "instanceId",
+            Timestamp = requestTimestamp,
             Filename = "attachment.pdf",
             Org = "ttd"
         };
@@ -40,6 +38,12 @@ namespace Altinn.FileScan.Tests.TestingServices
         {
             // Arrange
             Mock<IAppOwnerBlob> blobMock = new();
+            blobMock
+                .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new BlobPropertyModel
+                {
+                    LastModified = matchingTimestamp
+                });
             blobMock
                 .Setup(b => b.GetBlob(It.Is<string>(s => s == "ttd"), It.Is<string>(s => s == "blobstoragePath/org/attachment.pdf")))
                 .ReturnsAsync((Stream)null);
@@ -67,16 +71,6 @@ namespace Altinn.FileScan.Tests.TestingServices
         public async Task Scan_FilenameMissing_DataElementIdIsUsed()
         {
             // Arrange
-            DateTimeOffset requestTimestamp = new DateTimeOffset(2023, 1, 10, 8, 0, 0, new TimeSpan(0, 0, 0));
-            
-            Mock<IAppOwnerBlob> blobMock = new();
-            blobMock
-                .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(new BlobPropertyModel { LastModified = requestTimestamp });
-            blobMock
-                .Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync((Stream)null);
-
             Mock<IMuescheliClient> muescheliClientMock = new();
             muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.txt")))
                 .ReturnsAsync(ScanResult.OK);
@@ -97,6 +91,46 @@ namespace Altinn.FileScan.Tests.TestingServices
 
             // Assert
             muescheliClientMock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task Scan_TimestampDoesNotMatch_ErrorLogged()
+        {
+            // Arrange
+            Mock<IAppOwnerBlob> blobMock = new();
+            blobMock
+                .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new BlobPropertyModel { LastModified = nonMatchingTimestamp });
+            blobMock
+                .Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((Stream)null);
+
+            Mock<ILogger<IDataElement>> loggerMock = new Mock<ILogger<IDataElement>>();
+
+            Mock<IMuescheliClient> muescheliClientMock = new();
+            muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.txt")))
+                .ReturnsAsync(ScanResult.OK);
+
+            DataElementService sut = SetUpTestService(
+                appOwnerBlob: blobMock.Object, 
+                muescheliClient: muescheliClientMock.Object,
+                logger: loggerMock.Object);
+
+            var input = new DataElementScanRequest
+            {
+                BlobStoragePath = "blobstoragePath/org/attachment.pdf",
+                DataElementId = "dataElementId",
+                Timestamp = requestTimestamp,
+                InstanceId = "instanceId",
+                Org = "ttd"
+            };
+
+            // Act
+            await sut.Scan(input);
+
+            // Assert
+            loggerMock.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+            muescheliClientMock.Verify(x => x.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()), Times.Never);
         }
 
         [Theory]
@@ -164,14 +198,20 @@ namespace Altinn.FileScan.Tests.TestingServices
         private static DataElementService SetUpTestService(
             IAppOwnerBlob appOwnerBlob = null,
             IMuescheliClient muescheliClient = null,
-            IStorageClient storageClient = null)
+            IStorageClient storageClient = null,
+            ILogger<IDataElement> logger = null)
         {
             if (appOwnerBlob is null)
             {
-                var blobMock = new Mock<IAppOwnerBlob>();
-
+                Mock<IAppOwnerBlob> blobMock = new();
                 blobMock
-                    .Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>()))                    
+                    .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(new BlobPropertyModel 
+                    { 
+                        LastModified = matchingTimestamp
+                    });
+                blobMock
+                    .Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>()))
                     .ReturnsAsync((Stream)null);
 
                 appOwnerBlob = blobMock.Object;
@@ -195,7 +235,10 @@ namespace Altinn.FileScan.Tests.TestingServices
                 storageClient = storageClientMock.Object;
             }
 
-            var logger = new Mock<ILogger<IDataElement>>().Object;
+            if (logger == null)
+            {
+                logger = new Mock<ILogger<IDataElement>>().Object;
+            }
 
             return new DataElementService(appOwnerBlob, muescheliClient, storageClient, logger);
         }


### PR DESCRIPTION
Verify that blob and request timestamps match. File should not be scanned if timestamps do not match.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #34 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
