### PR TITLE
parse response body after verifying content

### DIFF
--- a/test/k6/src/tests/end2end.js
+++ b/test/k6/src/tests/end2end.js
@@ -68,8 +68,6 @@ export default function (data) {
     JSON.stringify(data.instance)
   );
 
-  const instanceId = JSON.parse(res.body).id;
-
   success = check(res, {
     "POST valid cloud event with all parameters status is 201.": (r) =>
       r.status === 201,
@@ -77,6 +75,8 @@ export default function (data) {
 
   addErrorCount(success);
   stopIterationOnFail("POST valid cloud event with all parameters", success, res);
+
+  const instanceId = JSON.parse(res.body).id;
 
   res = storageApi.postData(data.token, instanceId, "vedlegg", data.kattebilde);
   const dataElementId = JSON.parse(res.body).id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bug in use-case tests. 
Should verify response status code before attempting to parse content. 


## Related Issue(s)
- NA
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
