### PR TITLE
Added logic for app owner key value uri

### DIFF
--- a/src/Altinn.FileScan/Configuration/AppOwnerAzureStorageConfig.cs
+++ b/src/Altinn.FileScan/Configuration/AppOwnerAzureStorageConfig.cs
@@ -31,6 +31,11 @@
         public string OrgKeyVaultURI { get; set; }
 
         /// <summary>
+        /// Dictionary containing alternative key vault names for app owner
+        /// </summary>
+        public string OrgKeyVaultDict { get; set; } = "{}";
+
+        /// <summary>
         /// name of app owner storage account
         /// </summary>
         public string OrgStorageAccount { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added logic for handling access to key vault for service owners where the default naming standard is not followed. 

## Related Issue(s)
- #136 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green