### PR TITLE
Use docker compose v2

### DIFF
--- a/.github/workflows/use-case-PROD.yaml
+++ b/.github/workflows/use-case-PROD.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Run use case tests
       run:  |
               cd test/k6
-              docker-compose run k6 run /src/tests/end2end.js -e subskey=${{ secrets.APIM_SUBSKEY }} -e env=${{ vars.ENV }} -e org=${{ vars.ORG }} -e app=${{ vars.APP }} -e userId=${{ secrets.USER_ID }} -e personNumber=${{ secrets.PERSON_NUMBER }} -e partyId=${{ secrets.PARTY_ID }} -e username=${{ secrets.USERNAME }} -e password=${{ secrets.PASSWORD }}
+              docker compose run k6 run /src/tests/end2end.js -e subskey=${{ secrets.APIM_SUBSKEY }} -e env=${{ vars.ENV }} -e org=${{ vars.ORG }} -e app=${{ vars.APP }} -e userId=${{ secrets.USER_ID }} -e personNumber=${{ secrets.PERSON_NUMBER }} -e partyId=${{ secrets.PARTY_ID }} -e username=${{ secrets.USERNAME }} -e password=${{ secrets.PASSWORD }}
 
   report-status:
     name: Report status

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Run use case tests
       run:  |
               cd test/k6
-              docker-compose run k6 run /src/tests/end2end.js -e subskey=${{ secrets.APIM_SUBSKEY }} -e env=${{ vars.ENV }} -e org=${{ vars.ORG }}  -e app=${{ vars.APP }} -e userId=${{ secrets.USER_ID }} -e personNumber=${{ secrets.PERSON_NUMBER }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }} -e partyId=${{ secrets.PARTY_ID }}
+              docker compose run k6 run /src/tests/end2end.js -e subskey=${{ secrets.APIM_SUBSKEY }} -e env=${{ vars.ENV }} -e org=${{ vars.ORG }}  -e app=${{ vars.APP }} -e userId=${{ secrets.USER_ID }} -e personNumber=${{ secrets.PERSON_NUMBER }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }} -e partyId=${{ secrets.PARTY_ID }}
 
   report-status:
     name: Report status

--- a/test/k6/readme.md
+++ b/test/k6/readme.md
@@ -33,12 +33,12 @@ Run test suite by specifying filename.
 
 For example:
 
->$> docker-compose run k6 run /src/tests/end2end.js -e tokenGeneratorUserName=autotest -e tokenGeneratorUserPwd=*** -e env=at23 -e subskey=*** -e partyId=*** -e personNumber=*** -e org=ttd -e app=filescan-end-to-end
+>$> docker compose run k6 run /src/tests/end2end.js -e tokenGeneratorUserName=autotest -e tokenGeneratorUserPwd=*** -e env=at23 -e subskey=*** -e partyId=*** -e personNumber=*** -e org=ttd -e app=filescan-end-to-end
 
 
 The comand consists of three sections
 
-`docker-compose run` to run the test in a docker container
+`docker compose run` to run the test in a docker container
 
 `k6 run {path to test file}` pointing to the test file you want to run e.g. `/src/test/events.js`
 

--- a/test/k6/src/tests/end2end.js
+++ b/test/k6/src/tests/end2end.js
@@ -1,6 +1,6 @@
 /*
     Test script to platform events api with user token
-    Command: docker-compose run k6 run /src/tests/end2end.js -e tokenGeneratorUserName=autotest -e tokenGeneratorUserPwd=*** -e env=*** -e subskey=*** -e partyId=*** -e personNumber=*** -e org=ttd -e app=filescan-end-to-end
+    Command: docker compose run k6 run /src/tests/end2end.js -e tokenGeneratorUserName=autotest -e tokenGeneratorUserPwd=*** -e env=*** -e subskey=*** -e partyId=*** -e personNumber=*** -e org=ttd -e app=filescan-end-to-end
 */
 import { check, sleep } from "k6";
 import * as setupToken from "../setup.js";


### PR DESCRIPTION
## Description
Change how we run docker compose to use version 2. Version 1 is about to be unavailable on many build agents.

## Related Issue(s)
- Failing use case tests because of the docker-compose command not being found
