### PR TITLE
Revert "Update mcr.microsoft.com/dotnet/sdk Docker tag to v9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100-alpine3.20 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.404-alpine3.20 AS build
 
 # Copy event backend
 COPY src/Altinn.FileScan ./Altinn.FileScan


### PR DESCRIPTION
Reverts Altinn/altinn-file-scan#204

We will update the .Net framework separately.