### PR TITLE
Re-apply .NET 9 upgrade, with bugfix for cert generation

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,13 +31,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup .NET 8.0.* SDK
+    - name: Setup .NET 9.0.* SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          8.0.x
-          7.0.x
-          6.0.x
+          9.0.x
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0.405-alpine3.20 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0.102-alpine3.21 AS build
 
 # Copy event backend
 COPY src/Altinn.FileScan ./Altinn.FileScan
@@ -9,7 +9,7 @@ WORKDIR Altinn.FileScan/
 RUN dotnet build Altinn.FileScan.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.FileScan.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.12-alpine3.20 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.1-alpine3.21 AS final
 EXPOSE 5200
 WORKDIR /app
 COPY --from=build /app_output .

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These instructions will get you a copy of the filescan component up and running 
 
 ### Prerequisites
 
-1. [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+1. [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0)
 2. Newest [Git](https://git-scm.com/downloads)
 3. A code editor - we like [Visual Studio Code](https://code.visualstudio.com/download)
    - Install [Azure Functions extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions). You can also install the [Azure Tools extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack), which is recommended for working with Azure resources.

--- a/src/Altinn.FileScan.Functions/Altinn.FileScan.Functions.csproj
+++ b/src/Altinn.FileScan.Functions/Altinn.FileScan.Functions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,15 +13,15 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.24.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-  <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
+  <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
 </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.FileScan.Functions/Services/CertificateResolverService.cs
+++ b/src/Altinn.FileScan.Functions/Services/CertificateResolverService.cs
@@ -57,9 +57,9 @@ namespace Altinn.FileScan.Functions.Services
 
                 lock (_lockObject)
                 {
-                    _cachedX509Certificate = new X509Certificate2(
+                    _cachedX509Certificate = X509CertificateLoader.LoadPkcs12(
                         Convert.FromBase64String(certBase64),
-                        (string)null,
+                        null,
                         X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
                     _reloadTime = DateTime.UtcNow.AddSeconds(_certificateResolverSettings.CacheCertLifetimeInSeconds);
                     _logger.LogInformation("Certificate reloaded.");

--- a/src/Altinn.FileScan/Altinn.FileScan.csproj
+++ b/src/Altinn.FileScan/Altinn.FileScan.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -16,10 +16,10 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="4.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/test/Altinn.FileScan.Functions.Tests/Altinn.FileScan.Functions.Tests.csproj
+++ b/test/Altinn.FileScan.Functions.Tests/Altinn.FileScan.Functions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.71" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Altinn.FileScan.Tests/Altinn.FileScan.Tests.csproj
+++ b/test/Altinn.FileScan.Tests/Altinn.FileScan.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.71" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
- .NET 9 upgrade (cherry-picked changes from #236 )
- Replace deprecated/obsolete and [bug-related](https://github.com/dotnet/runtime/issues/110217) ctor `new X509Certificate2()` with `X509CertificateLoader.LoadPkcs12()`.
  - [Example of exception logs in App Insights ](https://portal.azure.com#@cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fde41df22-8dd0-435b-98dd-6152cd371e92%2FresourceGroups%2Faltinnplatform-at23-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fat23-platform-ai/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0utSE4tKMnMzyvmqlEoz0gtSlUoycxNLS5JzC1QSEotKU9NzVPQSEksSQUJaygZGRiZ6hoY6RoahBiaWBkYWRmYRylp6unhU2EBVKGgCQDJxruBagAAAA%253D%253D), showing that the exception stems from [attempt of generating certs](https://github.com/Altinn/altinn-file-scan/blob/main/src/Altinn.FileScan.Functions/Services/CertificateResolverService.cs#L60) in `CertificateResolverService.GetCertificateAsync`

## Related Issue(s)
- #213 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
