### PR TITLE
Add command for package upgrade in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ EXPOSE 5200
 WORKDIR /app
 COPY --from=build /app_output .
 
+# Upgrade all installed packages (temporary fix for CVE 2024-12797)
+RUN apk upgrade -a
+
 # setup the user and group
 # the user will have no password, using shell /bin/false and using the group dotnet
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet


### PR DESCRIPTION
## Description
Amends failing Trivy scan job (CVE 2024-12797), by including a package upgrade in the Alpine OS setup. This will upgrade the package(s) that contain the vulnerability, thus allowing the Trivy scan job to pass.

## Related Issue(s)
N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
