### PR TITLE
Add Renovate config that allows patching alpine image tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>Altinn/renovate-config"
+  ],
+  "regexManagers": [
+    {
+      "description": "Manage Alpine OS versions in container image tags",
+      "fileMatch": ["Dockerfile"],
+      "matchStrings": [
+        "(?:image:\\s+name:\\s*|image:\\s*|services:\\s+-\\s+|FROM\\s+)(?<depName>[\\S]+):(?<currentValue>[\\S]+)"
+      ],
+      "versioningTemplate": "regex:^(?<compatibility>[\\S]*\\d+\\.\\d+(?:\\.\\d+)?(?:[\\S]*)?-alpine-?)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
## Description
In our image refs ( e.g. `mcr.microsoft.com/dotnet/sdk:9.0.200-alpine3.21` ), Renovate is able to patch the first part (e.g. `9.0.200` -> `9.0.201`), but it does not support patches to the last part (e.g. `alpine3.21` -> `alpine3.22`.

This PRs extends this repo's renovate config to support patches of alpine OS image tags. The solution is pasted from [this article](https://aarongoldenthal.com/posts/managing-alpine-linux-based-container-images-with-renovate/), which describes a situation similar to ours.
Here is a regex playground where you can see how this manager will target the dependency details: https://regex101.com/r/qcgvRM/2


## Related Issue(s)
N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
