### PR TITLE
Avoid using caller's filename as input to virus scan

### DIFF
--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -5,7 +5,6 @@ using Altinn.FileScan.Repository.Interfaces;
 using Altinn.FileScan.Services.Interfaces;
 using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
-using System.Text.Json;
 
 namespace Altinn.FileScan.Services
 {
@@ -49,10 +48,8 @@ namespace Altinn.FileScan.Services
 
                 var stream = await _repository.GetBlob(scanRequest.Org, scanRequest.BlobStoragePath, scanRequest.StorageContainerNumber);
 
-                var filename = string.IsNullOrEmpty(scanRequest.Filename) ? $"{scanRequest.DataElementId}.txt" : scanRequest.Filename;
-                filename = filename.Contains("henning") ? "\"" + filename + "\"" : filename;
+                var filename = $"{scanRequest.DataElementId}.txt";
                 ScanResult scanResult = await _muescheliClient.ScanStream(stream, filename);
-                _logger.LogError($"Scan debug for: ${filename}${JsonSerializer.Serialize(scanResult)}");
 
                 FileScanResult fileScanResult = FileScanResult.Pending;
 

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -52,7 +52,7 @@ namespace Altinn.FileScan.Services
                 var filename = string.IsNullOrEmpty(scanRequest.Filename) ? $"{scanRequest.DataElementId}.txt" : scanRequest.Filename;
                 filename = filename.Contains("henning") ? "\"" + filename + "\"" : filename;
                 ScanResult scanResult = await _muescheliClient.ScanStream(stream, filename);
-                _logger.LogError($"Scan debug for: ${filename}${JsonSerializer.Serialize(scanRequest)}");
+                _logger.LogError($"Scan debug for: ${filename}${JsonSerializer.Serialize(scanResult)}");
 
                 FileScanResult fileScanResult = FileScanResult.Pending;
 

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -5,6 +5,7 @@ using Altinn.FileScan.Repository.Interfaces;
 using Altinn.FileScan.Services.Interfaces;
 using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
+using System.Text.Json;
 
 namespace Altinn.FileScan.Services
 {
@@ -49,7 +50,9 @@ namespace Altinn.FileScan.Services
                 var stream = await _repository.GetBlob(scanRequest.Org, scanRequest.BlobStoragePath, scanRequest.StorageContainerNumber);
 
                 var filename = string.IsNullOrEmpty(scanRequest.Filename) ? $"{scanRequest.DataElementId}.txt" : scanRequest.Filename;
+                filename = filename.Contains("henning") ? "\"" + filename + "\"" : filename;
                 ScanResult scanResult = await _muescheliClient.ScanStream(stream, filename);
+                _logger.LogError($"Scan debug for: ${filename}${JsonSerializer.Serialize(scanRequest)}");
 
                 FileScanResult fileScanResult = FileScanResult.Pending;
 

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -48,7 +48,7 @@ namespace Altinn.FileScan.Services
 
                 var stream = await _repository.GetBlob(scanRequest.Org, scanRequest.BlobStoragePath, scanRequest.StorageContainerNumber);
 
-                var filename = $"{scanRequest.DataElementId}.txt";
+                var filename = $"{scanRequest.DataElementId}.bin";
                 ScanResult scanResult = await _muescheliClient.ScanStream(stream, filename);
 
                 FileScanResult fileScanResult = FileScanResult.Pending;

--- a/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
+++ b/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
@@ -72,7 +72,7 @@ namespace Altinn.FileScan.Tests.TestingServices
         {
             // Arrange
             Mock<IMuescheliClient> muescheliClientMock = new();
-            muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.txt")))
+            muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.bin")))
                 .ReturnsAsync(ScanResult.OK);
 
             DataElementService sut = SetUpTestService(muescheliClient: muescheliClientMock.Object);

--- a/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
+++ b/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
@@ -49,7 +49,7 @@ namespace Altinn.FileScan.Tests.TestingServices
                 .ReturnsAsync((Stream)null);
 
             Mock<IMuescheliClient> muescheliClientMock = new();
-            muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "attachment.pdf")))
+            muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
                 .ReturnsAsync(ScanResult.OK);
 
             Mock<IStorageClient> storageClientMock = new();


### PR DESCRIPTION
## Description
- Avoid using caller's filename as input to virus scan

## Related Issue(s)
- #644

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
