### PR TITLE
Add environment specific cookie name

### DIFF
--- a/test/k6/src/config.js
+++ b/test/k6/src/config.js
@@ -9,9 +9,22 @@ export var baseUrls = {
   prod: "altinn.no"
 };
 
+// Auth cookie names in the different environments. NB: Must be updated until changes
+// are rolled out to all environments
+export var authCookieNames = {
+  at21: '.AspxAuthCloud',
+  at22: '.AspxAuthCloud',
+  at23: '.AspxAuthCloud',
+  at24: '.AspxAuthCloud',
+  tt02: '.AspxAuthTT02',
+  yt01: '.AspxAuthYt',
+  prod: '.AspxAuthProd',
+};
+
 //Get values from environment
 const environment = __ENV.env.toLowerCase();
 export let baseUrl = baseUrls[environment];
+export let authCookieName = authCookieNames[environment];
 
 //AltinnTestTools
 export var tokenGenerator = {

--- a/test/k6/src/setup.js
+++ b/test/k6/src/setup.js
@@ -59,7 +59,7 @@ function getAspxAuth(username, password) {
 
   stopIterationOnFail("Authentication towards Altinn 2 Failed", success, res);
 
-  const cookieName = ".ASPXAUTH";
+  const cookieName = config.authCookieName;
   var cookieValue = res.cookies[cookieName][0].value;
   return cookieValue;
 }
@@ -69,7 +69,7 @@ export function getAltinnStudioRuntimeToken(aspxauthCookie) {
   var endpoint = config.platformAuthentication.authentication + '?goto=' + config.platformAuthentication.refresh;
 
   var params = {
-    cookies: { '.ASPXAUTH': aspxauthCookie },
+    cookies: { [config.authCookieName]: aspxauthCookie },
   };
 
   var res = http.get(endpoint, params);
@@ -84,5 +84,5 @@ export function getAltinnStudioRuntimeToken(aspxauthCookie) {
 export function clearCookies() {
   var jar = http.cookieJar();
   jar.set('https://' + config.baseUrl, 'AltinnStudioRuntime', 'test', { expires: 'Mon, 02 Jan 2010 15:04:05 MST' });
-  jar.set('https://' + config.baseUrl, '.ASPXAUTH', 'test', { expires: 'Mon, 02 Jan 2010 15:04:05 MST' });
+  jar.set('https://' + config.baseUrl, config.authCookieName, 'test', { expires: 'Mon, 02 Jan 2010 15:04:05 MST' });
 }


### PR DESCRIPTION
## Description
The name of the AUTH cookie in Altinn ii changes name between environments. This change updates the use-case tests that rely on portal login.