### PR TITLE
Fix Renovate patches of Dockerfile alpine images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
         "/Dockerfile/"
       ],
       "matchStrings": [
-        "(?:image:\\s+name:\\s*|image:\\s*|services:\\s+-\\s+|FROM\\s+)(?<depName>[\\S]+):(?<currentValue>[\\S]+)"
+        "(?:FROM\\s+)(?<depName>[\\S]+):(?<currentValue>[\\S]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
       "versioningTemplate": "regex:^(?<compatibility>[\\S]*\\d+\\.\\d+(?:\\.\\d+)?(?:[\\S]*)?-alpine-?)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
       "datasourceTemplate": "docker"


### PR DESCRIPTION
## Description
I looked more closely at the config, and it seems that the `matchStrings` regex isn't able to capture the relevant groups correctly.
[Existing regex playground](https://regex101.com/r/DrxXJ7/1) illustrates how the capture groups _depName_ and _currentValue_ are not correctly matched in the string `FROM mcr.microsoft.com/dotnet/sdk:9.0.301-alpine3.21`.  The issue seems to be with the suffixed SHA256 hash.

[New regex](https://regex101.com/r/gMoR4G/1) correctly captures _depName_, _currentValue_, and the newly added _currentDigest_.

## Related Issue(s)
- #286 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
