### PR TITLE
Remove newline characters when logging user input data

### DIFF
--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -40,7 +40,7 @@ namespace Altinn.FileScan.Services
                 {
                     // we replace newline characters in log messages to avoid log injection attacks
                     _logger.LogError(
-                        "Scan request timestamp != blob last modified timestamp, scan request aborted. Instance Id: {instanceId}, DataElementId: {dataElementId}, timestamp diff: {timeDiff} seconds", 
+                        "Scan request timestamp != blob last modified timestamp, scan request aborted. Instance Id: {InstanceId}, DataElementId: {DataElementId}, timestamp diff: {TimeDiff} seconds", 
                         scanRequest.InstanceId.Replace(Environment.NewLine, string.Empty), 
                         scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty),
                         scanRequest.Timestamp.Subtract(blobProps.LastModified).TotalSeconds);
@@ -65,7 +65,7 @@ namespace Altinn.FileScan.Services
                     case ScanResult.ERROR:
                     case ScanResult.PARSE_ERROR:
                     case ScanResult.UNDEFINED:
-                        _logger.LogError("Scan of {dataElementId} completed with unexpected result {scanResult}.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty), scanResult);
+                        _logger.LogError("Scan of {DataElementId} completed with unexpected result {ScanResult}.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty), scanResult);
                         throw MuescheliScanResultException.Create(scanRequest.DataElementId, scanResult);
                 }
 
@@ -79,7 +79,7 @@ namespace Altinn.FileScan.Services
             }
             catch (MuescheliHttpException e)
             {
-                _logger.LogError(e, "Scan of {dataElementId} failed with an http exception.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty));
+                _logger.LogError(e, "Scan of {DataElementId} failed with an http exception.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty));
                 throw;
             }
         }

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -38,10 +38,11 @@ namespace Altinn.FileScan.Services
 
                 if (blobProps.LastModified != scanRequest.Timestamp)
                 {
+                    // we replace newline characters in log messages to avoid log injection attacks
                     _logger.LogError(
                         "Scan request timestamp != blob last modified timestamp, scan request aborted. Instance Id: {instanceId}, DataElementId: {dataElementId}, timestamp diff: {timeDiff} seconds", 
-                        scanRequest.InstanceId, 
-                        scanRequest.DataElementId,
+                        scanRequest.InstanceId.Replace(Environment.NewLine, string.Empty), 
+                        scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty),
                         scanRequest.Timestamp.Subtract(blobProps.LastModified).TotalSeconds);
                     return;
                 }
@@ -64,7 +65,7 @@ namespace Altinn.FileScan.Services
                     case ScanResult.ERROR:
                     case ScanResult.PARSE_ERROR:
                     case ScanResult.UNDEFINED:
-                        _logger.LogError("Scan of {dataElementId} completed with unexpected result {scanResult}.", scanRequest.DataElementId, scanResult);
+                        _logger.LogError("Scan of {dataElementId} completed with unexpected result {scanResult}.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty), scanResult);
                         throw MuescheliScanResultException.Create(scanRequest.DataElementId, scanResult);
                 }
 
@@ -78,7 +79,7 @@ namespace Altinn.FileScan.Services
             }
             catch (MuescheliHttpException e)
             {
-                _logger.LogError(e, "Scan of {dataElementId} failed with an http exception.", scanRequest.DataElementId);
+                _logger.LogError(e, "Scan of {dataElementId} failed with an http exception.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty));
                 throw;
             }
         }

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -16,12 +16,12 @@ namespace Altinn.FileScan.Services
         private readonly IAppOwnerBlob _repository;
         private readonly IStorageClient _storageClient;
         private readonly IMuescheliClient _muescheliClient;
-        private readonly ILogger<IDataElement> _logger;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataElementService"/> class.
         /// </summary>
-        public DataElementService(IAppOwnerBlob repository, IMuescheliClient muescheliClient, IStorageClient storageClient, ILogger<IDataElement> logger)
+        public DataElementService(IAppOwnerBlob repository, IMuescheliClient muescheliClient, IStorageClient storageClient, ILogger<DataElementService> logger)
         {
             _repository = repository;
             _storageClient = storageClient;


### PR DESCRIPTION
Newline characters could enable a malicious user to create fake log entries

## Description
Prevent potential logging injection by stripping user input data that could contain newline characters

## Related Issue(s)
https://github.com/Altinn/team-core-private/issues/320

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
