### PR TITLE
fix: downgrade Azure.Monitor.OpenTelemetry.Exporter to 1.8.2

### DIFF
--- a/src/Altinn.FileScan/Altinn.FileScan.csproj
+++ b/src/Altinn.FileScan/Altinn.FileScan.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />


### PR DESCRIPTION
## Description
Revert upgrade of `Azure.Monitor.OpenTelemetry.Exporter`