### PR TITLE
chore: add csharpier for code formatting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "1.2.6",
+      "commands": [
+        "csharpier"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+.git/
+*.xml
+*.csproj
+*.props
+*.targets

--- a/.csharpierrc.yaml
+++ b/.csharpierrc.yaml
@@ -1,0 +1,4 @@
+printWidth: 120
+useTabs: false
+tabWidth: 4
+endOfLine: auto

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# More info:
+# https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/
+
+2aa8ea650eb28558227db1e73dbefec573ecea43 # style: format codebase with csharpier

--- a/.github/workflows/verify-formatting.yml
+++ b/.github/workflows/verify-formatting.yml
@@ -1,0 +1,36 @@
+name: Verify formatting
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - '.csharpierrc.yaml'
+      - '.csharpierignore'
+      - '.config/dotnet-tools.json'
+      - 'Directory.Build.props'
+      - '.github/workflows/verify-formatting.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  verify-no-changes:
+    if: github.event.pull_request.user.login != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            10.0.x
+      - name: Install csharpier
+        run: dotnet tool restore
+      - name: Run csharpier
+        run: dotnet csharpier check .

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="CSharpier.MsBuild" Version="1.2.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/Altinn.FileScan.Functions/Clients/FileScanClient.cs
+++ b/src/Altinn.FileScan.Functions/Clients/FileScanClient.cs
@@ -32,7 +32,8 @@ public class FileScanClient : IFileScanClient
         IAccessTokenGenerator accessTokenGenerator,
         ICertificateResolverService certificateResolverService,
         IOptions<PlatformSettings> platformSettings,
-        ILogger<FileScanClient> logger)
+        ILogger<FileScanClient> logger
+    )
     {
         _accessTokenGenerator = accessTokenGenerator;
         _certificateResolverService = certificateResolverService;

--- a/src/Altinn.FileScan.Functions/Extensions/HttpClientExtension.cs
+++ b/src/Altinn.FileScan.Functions/Extensions/HttpClientExtension.cs
@@ -18,12 +18,14 @@ public static class HttpClientExtension
     /// <param name="content">The http content</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> PostAsync(this HttpClient httpClient, string requestUri, HttpContent content, string platformAccessToken)
+    public static Task<HttpResponseMessage> PostAsync(
+        this HttpClient httpClient,
+        string requestUri,
+        HttpContent content,
+        string platformAccessToken
+    )
     {
-        HttpRequestMessage request = new(HttpMethod.Post, new Uri(requestUri, UriKind.Relative))
-        {
-            Content = content
-        };
+        HttpRequestMessage request = new(HttpMethod.Post, new Uri(requestUri, UriKind.Relative)) { Content = content };
 
         request.Headers.Add("PlatformAccessToken", platformAccessToken);
         return httpClient.SendAsync(request, CancellationToken.None);

--- a/src/Altinn.FileScan.Functions/FileScanInbound.cs
+++ b/src/Altinn.FileScan.Functions/FileScanInbound.cs
@@ -21,7 +21,9 @@ public class FileScanInbound(IFileScanClient fileScanClient, ILoggerFactory logg
     /// Retrieves dataElements from file-scna-inbound queue and send to FileScans rest-api
     /// </summary>
     [Function("FileScanInbound")]
-    public async Task Run([QueueTrigger("file-scan-inbound", Connection = "QueueStorage")] string dataElementScanRequest)
+    public async Task Run(
+        [QueueTrigger("file-scan-inbound", Connection = "QueueStorage")] string dataElementScanRequest
+    )
     {
         _logger.LogInformation("C# Queue trigger function processed: {dataElement}", dataElementScanRequest);
         await fileScanClient.PostDataElementScanRequest(dataElementScanRequest);

--- a/src/Altinn.FileScan.Functions/Program.cs
+++ b/src/Altinn.FileScan.Functions/Program.cs
@@ -5,7 +5,6 @@ using Altinn.FileScan.Functions.Clients.Interfaces;
 using Altinn.FileScan.Functions.Configuration;
 using Altinn.FileScan.Functions.Services;
 using Altinn.FileScan.Functions.Services.Interfaces;
-
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,20 +15,26 @@ var host = new HostBuilder()
     .ConfigureServices(s =>
     {
         s.AddOptions<PlatformSettings>()
-         .Configure<IConfiguration>((settings, configuration) =>
-         {
-             configuration.GetSection("Platform").Bind(settings);
-         });
+            .Configure<IConfiguration>(
+                (settings, configuration) =>
+                {
+                    configuration.GetSection("Platform").Bind(settings);
+                }
+            );
         s.AddOptions<KeyVaultSettings>()
-        .Configure<IConfiguration>((settings, configuration) =>
-        {
-            configuration.GetSection("KeyVault").Bind(settings);
-        });
+            .Configure<IConfiguration>(
+                (settings, configuration) =>
+                {
+                    configuration.GetSection("KeyVault").Bind(settings);
+                }
+            );
         s.AddOptions<CertificateResolverSettings>()
-         .Configure<IConfiguration>((settings, configuration) =>
-         {
-             configuration.GetSection("CertificateResolver").Bind(settings);
-         });
+            .Configure<IConfiguration>(
+                (settings, configuration) =>
+                {
+                    configuration.GetSection("CertificateResolver").Bind(settings);
+                }
+            );
 
         s.AddSingleton<IKeyVaultService, KeyVaultService>();
         s.AddSingleton<ITelemetryInitializer, TelemetryInitializer>();

--- a/src/Altinn.FileScan.Functions/Services/CertificateResolverService.cs
+++ b/src/Altinn.FileScan.Functions/Services/CertificateResolverService.cs
@@ -24,7 +24,8 @@ public class CertificateResolverService(
     ILogger<CertificateResolverService> logger,
     IOptions<CertificateResolverSettings> certificateResolverSettings,
     IKeyVaultService keyVaultService,
-    IOptions<KeyVaultSettings> keyVaultSettings) : ICertificateResolverService
+    IOptions<KeyVaultSettings> keyVaultSettings
+) : ICertificateResolverService
 {
     private readonly CertificateResolverSettings _certificateResolverSettings = certificateResolverSettings.Value;
     private readonly KeyVaultSettings _keyVaultSettings = keyVaultSettings.Value;
@@ -42,7 +43,8 @@ public class CertificateResolverService(
         {
             var certificate = await keyVaultService.GetCertificateAsync(
                 _keyVaultSettings.KeyVaultURI,
-                _keyVaultSettings.PlatformCertSecretId);
+                _keyVaultSettings.PlatformCertSecretId
+            );
             lock (_lockObject)
             {
                 _cachedX509Certificate = certificate;

--- a/src/Altinn.FileScan.Functions/Services/KeyVaultService.cs
+++ b/src/Altinn.FileScan.Functions/Services/KeyVaultService.cs
@@ -22,13 +22,19 @@ public class KeyVaultService : IKeyVaultService
     public async Task<X509Certificate2> GetCertificateAsync(string vaultUri, string secretId)
     {
         CertificateClient certificateClient = new(new Uri(vaultUri), new DefaultAzureCredential());
-        AsyncPageable<CertificateProperties> certificatePropertiesPage = certificateClient.GetPropertiesOfCertificateVersionsAsync(secretId);
+        AsyncPageable<CertificateProperties> certificatePropertiesPage =
+            certificateClient.GetPropertiesOfCertificateVersionsAsync(secretId);
         await foreach (CertificateProperties certificateProperties in certificatePropertiesPage)
         {
-            if (certificateProperties.Enabled == true &&
-                (certificateProperties.ExpiresOn == null || certificateProperties.ExpiresOn >= DateTime.UtcNow))
+            if (
+                certificateProperties.Enabled == true
+                && (certificateProperties.ExpiresOn == null || certificateProperties.ExpiresOn >= DateTime.UtcNow)
+            )
             {
-                X509Certificate2 cert = await certificateClient.DownloadCertificateAsync(certificateProperties.Name, certificateProperties.Version);
+                X509Certificate2 cert = await certificateClient.DownloadCertificateAsync(
+                    certificateProperties.Name,
+                    certificateProperties.Version
+                );
                 return cert;
             }
         }

--- a/src/Altinn.FileScan/Clients/MuescheliClient.cs
+++ b/src/Altinn.FileScan/Clients/MuescheliClient.cs
@@ -27,9 +27,7 @@ public class MuescheliClient : IMuescheliClient
     /// <summary>
     /// Initializes a new instance of the <see cref="MuescheliClient"/> class.
     /// </summary>
-    public MuescheliClient(
-        HttpClient httpClient,
-        IOptions<PlatformSettings> settings)
+    public MuescheliClient(HttpClient httpClient, IOptions<PlatformSettings> settings)
     {
         _client = httpClient;
         _client.BaseAddress = new Uri(settings.Value.ApiMuescheliEndpoint);
@@ -37,7 +35,7 @@ public class MuescheliClient : IMuescheliClient
         _serializerOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
-            Converters = { new JsonStringEnumConverter() }
+            Converters = { new JsonStringEnumConverter() },
         };
     }
 
@@ -46,10 +44,7 @@ public class MuescheliClient : IMuescheliClient
     {
         string endpoint = $"scan";
 
-        using var content = new MultipartFormDataContent
-        {
-            { new StreamContent(stream), "file", filename }
-        };
+        using var content = new MultipartFormDataContent { { new StreamContent(stream), "file", filename } };
 
         HttpResponseMessage response = await _client.PostAsync(endpoint, content);
 
@@ -60,7 +55,8 @@ public class MuescheliClient : IMuescheliClient
 
         var responseString = await response.Content.ReadAsStringAsync();
 
-        MuescheliResponse r = JsonSerializer.Deserialize<List<MuescheliResponse>>(responseString, _serializerOptions)
+        MuescheliResponse r = JsonSerializer
+            .Deserialize<List<MuescheliResponse>>(responseString, _serializerOptions)
             .First();
 
         return r.Result;

--- a/src/Altinn.FileScan/Clients/StorageClient.cs
+++ b/src/Altinn.FileScan/Clients/StorageClient.cs
@@ -24,10 +24,7 @@ public class StorageClient : IStorageClient
     /// <summary>
     /// Initializes a new instance of the <see cref="StorageClient"/> class.
     /// </summary>
-    public StorageClient(
-        HttpClient httpClient,
-        IAccessToken accessToken,
-        IOptions<PlatformSettings> settings)
+    public StorageClient(HttpClient httpClient, IAccessToken accessToken, IOptions<PlatformSettings> settings)
     {
         _accessTokenService = accessToken;
 
@@ -47,7 +44,10 @@ public class StorageClient : IStorageClient
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new PlatformHttpException(response, "Unexpected response from StorageClient when setting file scan status.");
+            throw new PlatformHttpException(
+                response,
+                "Unexpected response from StorageClient when setting file scan status."
+            );
         }
     }
 
@@ -68,6 +68,9 @@ public class StorageClient : IStorageClient
             }
         }
 
-        throw new PlatformHttpException(response, "Unexpected response from StorageClient when checking if data element exists.");
+        throw new PlatformHttpException(
+            response,
+            "Unexpected response from StorageClient when checking if data element exists."
+        );
     }
 }

--- a/src/Altinn.FileScan/Configuration/PlatformSettings.cs
+++ b/src/Altinn.FileScan/Configuration/PlatformSettings.cs
@@ -15,5 +15,5 @@ public class PlatformSettings
     /// <summary>
     /// Sets or sets the url for the Muescheli API endpoint
     /// </summary>
-    public string ApiMuescheliEndpoint { get;  set; }
+    public string ApiMuescheliEndpoint { get; set; }
 }

--- a/src/Altinn.FileScan/Exceptions/MuescheliHttpException.cs
+++ b/src/Altinn.FileScan/Exceptions/MuescheliHttpException.cs
@@ -21,7 +21,10 @@ public class MuescheliHttpException(HttpResponseMessage response, string message
     /// <summary>
     /// Creates a new <see cref="MuescheliHttpException"/> combining the response message and
     /// </summary>
-    public static async Task<MuescheliHttpException> CreateAsync(HttpStatusCode statusCode, HttpResponseMessage response)
+    public static async Task<MuescheliHttpException> CreateAsync(
+        HttpStatusCode statusCode,
+        HttpResponseMessage response
+    )
     {
         string responseMessage = await response.Content.ReadAsStringAsync();
 

--- a/src/Altinn.FileScan/Extensions/HttpClientExtension.cs
+++ b/src/Altinn.FileScan/Extensions/HttpClientExtension.cs
@@ -18,12 +18,14 @@ public static class HttpClientExtension
     /// <param name="content">The http content</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> PutAsync(this HttpClient httpClient, string requestUri, HttpContent content, string platformAccessToken)
+    public static Task<HttpResponseMessage> PutAsync(
+        this HttpClient httpClient,
+        string requestUri,
+        HttpContent content,
+        string platformAccessToken
+    )
     {
-        HttpRequestMessage request = new(HttpMethod.Put, new Uri(requestUri, UriKind.Relative))
-        {
-            Content = content
-        };
+        HttpRequestMessage request = new(HttpMethod.Put, new Uri(requestUri, UriKind.Relative)) { Content = content };
 
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
@@ -40,7 +42,11 @@ public static class HttpClientExtension
     /// <param name="requestUri">The request Uri</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> GetAsync(this HttpClient httpClient, string requestUri, string platformAccessToken)
+    public static Task<HttpResponseMessage> GetAsync(
+        this HttpClient httpClient,
+        string requestUri,
+        string platformAccessToken
+    )
     {
         HttpRequestMessage request = new(HttpMethod.Get, new Uri(requestUri, UriKind.Relative));
 

--- a/src/Altinn.FileScan/Health/HealthCheck.cs
+++ b/src/Altinn.FileScan/Health/HealthCheck.cs
@@ -18,9 +18,11 @@ public class HealthCheck : IHealthCheck
     /// <param name="context">The healtcheck context</param>
     /// <param name="cancellationToken">The cancellationtoken</param>
     /// <returns></returns>
-    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default
+    )
     {
-        return Task.FromResult(
-            HealthCheckResult.Healthy("A healthy result."));
+        return Task.FromResult(HealthCheckResult.Healthy("A healthy result."));
     }
 }

--- a/src/Altinn.FileScan/Models/ScanResult.cs
+++ b/src/Altinn.FileScan/Models/ScanResult.cs
@@ -28,5 +28,5 @@ public enum ScanResult
     /// <summary>
     /// An error occured.
     /// </summary>
-    PARSE_ERROR
+    PARSE_ERROR,
 }

--- a/src/Altinn.FileScan/Program.cs
+++ b/src/Altinn.FileScan/Program.cs
@@ -65,9 +65,7 @@ void ConfigureWebHostCreationLogging()
 {
     var logFactory = LoggerFactory.Create(builder =>
     {
-        builder
-            .AddFilter("Altinn.FileScan.Program", LogLevel.Debug)
-            .AddConsole();
+        builder.AddFilter("Altinn.FileScan.Program", LogLevel.Debug).AddConsole();
     });
 
     logger = logFactory.CreateLogger<Program>();
@@ -141,15 +139,13 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         KeyValuePair.Create("service.name", (object)"platform-filescan"),
     };
 
-    services.AddOpenTelemetry()
+    services
+        .AddOpenTelemetry()
         .ConfigureResource(resourceBuilder => resourceBuilder.AddAttributes(attributes))
         .WithMetrics(metrics =>
         {
             metrics.AddAspNetCoreInstrumentation();
-            metrics.AddMeter(
-                "Microsoft.AspNetCore.Hosting",
-                "Microsoft.AspNetCore.Server.Kestrel",
-                "System.Net.Http");
+            metrics.AddMeter("Microsoft.AspNetCore.Hosting", "Microsoft.AspNetCore.Server.Kestrel", "System.Net.Http");
         })
         .WithTracing(tracing =>
         {
@@ -175,7 +171,9 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.Configure<PlatformSettings>(config.GetSection("PlatformSettings"));
     services.Configure<KeyVaultSettings>(config.GetSection("kvSetting"));
     services.Configure<AccessTokenSettings>(config.GetSection("AccessTokenSettings"));
-    services.Configure<Altinn.Common.AccessTokenClient.Configuration.AccessTokenSettings>(config.GetSection("AccessTokenSettings"));
+    services.Configure<Altinn.Common.AccessTokenClient.Configuration.AccessTokenSettings>(
+        config.GetSection("AccessTokenSettings")
+    );
     services.Configure<AppOwnerAzureStorageConfig>(config.GetSection("AppOwnerAzureStorageConfig"));
     services.Configure<StorageClientSettings>(config.GetSection("StorageClientSettings"));
 
@@ -193,7 +191,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddSingleton<IBlobContainerClientProvider, BlobContainerClientProvider>();
     services.AddSingleton<IAppOwnerBlob, AppOwnerBlobRepository>();
 
-    services.AddHttpClient<IStorageClient, StorageClient>()
+    services
+        .AddHttpClient<IStorageClient, StorageClient>()
         .ConfigurePrimaryHttpMessageHandler(sp =>
         {
             StorageClientSettings settings = sp.GetRequiredService<IOptions<StorageClientSettings>>().Value;
@@ -205,36 +204,40 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
                 ConnectTimeout = TimeSpan.FromSeconds(settings.ConnectTimeoutSeconds),
             };
         })
-
         // PooledConnectionLifetime now owns connection recycling; disable the
         // IHttpClientFactory's default 2-minute handler rotation to avoid managing it twice.
         .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
 
     services.AddHttpClient<IMuescheliClient, MuescheliClient>();
 
-    services.AddAuthentication(JwtCookieDefaults.AuthenticationScheme)
-          .AddJwtCookie(JwtCookieDefaults.AuthenticationScheme, options =>
-          {
-              GeneralSettings generalSettings = config.GetSection("GeneralSettings").Get<GeneralSettings>();
-              options.JwtCookieName = generalSettings.JwtCookieName;
-              options.MetadataAddress = generalSettings.OpenIdWellKnownEndpoint;
-              options.TokenValidationParameters = new TokenValidationParameters
-              {
-                  ValidateIssuerSigningKey = true,
-                  ValidateIssuer = false,
-                  ValidateAudience = false,
-                  RequireExpirationTime = true,
-                  ValidateLifetime = true,
-                  ClockSkew = TimeSpan.Zero
-              };
+    services
+        .AddAuthentication(JwtCookieDefaults.AuthenticationScheme)
+        .AddJwtCookie(
+            JwtCookieDefaults.AuthenticationScheme,
+            options =>
+            {
+                GeneralSettings generalSettings = config.GetSection("GeneralSettings").Get<GeneralSettings>();
+                options.JwtCookieName = generalSettings.JwtCookieName;
+                options.MetadataAddress = generalSettings.OpenIdWellKnownEndpoint;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuerSigningKey = true,
+                    ValidateIssuer = false,
+                    ValidateAudience = false,
+                    RequireExpirationTime = true,
+                    ValidateLifetime = true,
+                    ClockSkew = TimeSpan.Zero,
+                };
 
-              if (builder.Environment.IsDevelopment())
-              {
-                  options.RequireHttpsMetadata = false;
-              }
-          });
+                if (builder.Environment.IsDevelopment())
+                {
+                    options.RequireHttpsMetadata = false;
+                }
+            }
+        );
 
-    services.AddAuthorizationBuilder()
+    services
+        .AddAuthorizationBuilder()
         .AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
 
     services.AddSwaggerGen(swaggerGenOptions => AddSwaggerGen(swaggerGenOptions));
@@ -258,18 +261,24 @@ void AddSwaggerGen(SwaggerGenOptions swaggerGenOptions)
 
 void AddAzureMonitorTelemetryExporters(IServiceCollection services, string applicationInsightsConnectionString)
 {
-    services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddAzureMonitorLogExporter(o =>
-    {
-        o.ConnectionString = applicationInsightsConnectionString;
-    }));
-    services.ConfigureOpenTelemetryMeterProvider(metrics => metrics.AddAzureMonitorMetricExporter(o =>
-    {
-        o.ConnectionString = applicationInsightsConnectionString;
-    }));
-    services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddAzureMonitorTraceExporter(o =>
-    {
-        o.ConnectionString = applicationInsightsConnectionString;
-    }));
+    services.Configure<OpenTelemetryLoggerOptions>(logging =>
+        logging.AddAzureMonitorLogExporter(o =>
+        {
+            o.ConnectionString = applicationInsightsConnectionString;
+        })
+    );
+    services.ConfigureOpenTelemetryMeterProvider(metrics =>
+        metrics.AddAzureMonitorMetricExporter(o =>
+        {
+            o.ConnectionString = applicationInsightsConnectionString;
+        })
+    );
+    services.ConfigureOpenTelemetryTracerProvider(tracing =>
+        tracing.AddAzureMonitorTraceExporter(o =>
+        {
+            o.ConnectionString = applicationInsightsConnectionString;
+        })
+    );
 }
 
 void Configure()

--- a/src/Altinn.FileScan/Repository/BlobContainerClientProvider.cs
+++ b/src/Altinn.FileScan/Repository/BlobContainerClientProvider.cs
@@ -22,7 +22,8 @@ namespace Altinn.FileScan.Repository;
 public class BlobContainerClientProvider(
     IOptions<AppOwnerAzureStorageConfig> storageConfiguration,
     ILogger<BlobContainerClientProvider> logger,
-    IMemoryCache memoryCache) : IBlobContainerClientProvider
+    IMemoryCache memoryCache
+) : IBlobContainerClientProvider
 {
     private const string _credsCacheKey = "creds";
 
@@ -48,14 +49,15 @@ public class BlobContainerClientProvider(
                 string accountName = string.Format(_storageConfig.OrgStorageAccount, org);
                 if (storageAccountNumber != null)
                 {
-                    accountName = accountName.Substring(0, accountName.Length - 2) + ((int)storageAccountNumber).ToString("D2");
+                    accountName =
+                        accountName.Substring(0, accountName.Length - 2) + ((int)storageAccountNumber).ToString("D2");
                 }
 
                 UriBuilder fullUri = new()
                 {
                     Scheme = "https",
                     Host = $"{accountName}.blob.core.windows.net",
-                    Path = $"{containerName}"
+                    Path = $"{containerName}",
                 };
 
                 client = new BlobContainerClient(fullUri.Uri, GetCachedCredentials());

--- a/src/Altinn.FileScan/Services/AccessTokenService.cs
+++ b/src/Altinn.FileScan/Services/AccessTokenService.cs
@@ -26,7 +26,12 @@ public class AccessTokenService : IAccessToken
     /// <summary>
     /// Initializes a new instance of the <see cref="AccessTokenService"/> class.
     /// </summary>
-    public AccessTokenService(IPlatformKeyVault keyVault, IAccessTokenGenerator accessTokenGenerator, IMemoryCache cache, IOptions<AccessTokenSettings> settings)
+    public AccessTokenService(
+        IPlatformKeyVault keyVault,
+        IAccessTokenGenerator accessTokenGenerator,
+        IMemoryCache cache,
+        IOptions<AccessTokenSettings> settings
+    )
     {
         _keyVault = keyVault;
         _accessTokenGenerator = accessTokenGenerator;
@@ -34,7 +39,7 @@ public class AccessTokenService : IAccessToken
 
         _cacheOptions = new()
         {
-            AbsoluteExpiration = new DateTimeOffset(DateTime.Now.AddSeconds(settings.Value.TokenLifetimeInSeconds - 2))
+            AbsoluteExpiration = new DateTimeOffset(DateTime.Now.AddSeconds(settings.Value.TokenLifetimeInSeconds - 2)),
         };
     }
 

--- a/src/Altinn.FileScan/Services/AppOwnerKeyVaultService.cs
+++ b/src/Altinn.FileScan/Services/AppOwnerKeyVaultService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Altinn.FileScan.Services.Interfaces;
-
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 

--- a/src/Altinn.FileScan/Services/DataElementService.cs
+++ b/src/Altinn.FileScan/Services/DataElementService.cs
@@ -18,7 +18,12 @@ namespace Altinn.FileScan.Services;
 /// <remarks>
 /// Initializes a new instance of the <see cref="DataElementService"/> class.
 /// </remarks>
-public class DataElementService(IAppOwnerBlob repository, IMuescheliClient muescheliClient, IStorageClient storageClient, ILogger<DataElementService> logger) : IDataElement
+public class DataElementService(
+    IAppOwnerBlob repository,
+    IMuescheliClient muescheliClient,
+    IStorageClient storageClient,
+    ILogger<DataElementService> logger
+) : IDataElement
 {
     private readonly IAppOwnerBlob _repository = repository;
     private readonly IStorageClient _storageClient = storageClient;
@@ -33,7 +38,11 @@ public class DataElementService(IAppOwnerBlob repository, IMuescheliClient muesc
             BlobPropertyModel? blobProps = null;
             try
             {
-                blobProps = await _repository.GetBlobProperties(scanRequest.Org, scanRequest.BlobStoragePath, scanRequest.StorageAccountNumber);
+                blobProps = await _repository.GetBlobProperties(
+                    scanRequest.Org,
+                    scanRequest.BlobStoragePath,
+                    scanRequest.StorageAccountNumber
+                );
             }
             catch (RequestFailedException exception)
             {
@@ -42,16 +51,20 @@ public class DataElementService(IAppOwnerBlob repository, IMuescheliClient muesc
                     "Blob not found with the following parameters. Org: {Org}, BlobStoragePath: {BlobStoragePath}, StorageAccountNumber: {StorageAccountNumber}",
                     scanRequest.Org.Replace(Environment.NewLine, string.Empty),
                     scanRequest.BlobStoragePath.Replace(Environment.NewLine, string.Empty),
-                    scanRequest.StorageAccountNumber);
+                    scanRequest.StorageAccountNumber
+                );
 
                 bool result = await _storageClient.DataElementExists(scanRequest.InstanceId, scanRequest.DataElementId);
                 if (result)
                 {
-                    RequestFailedException requestFailedException = new($"DataElement {scanRequest.DataElementId} found and blob does not exist");
+                    RequestFailedException requestFailedException = new(
+                        $"DataElement {scanRequest.DataElementId} found and blob does not exist"
+                    );
                     _logger.LogError(
                         requestFailedException,
                         "DataElement {DataElementId} found and blob does not exist",
-                        scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty));
+                        scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty)
+                    );
                     throw requestFailedException;
                 }
 
@@ -62,16 +75,23 @@ public class DataElementService(IAppOwnerBlob repository, IMuescheliClient muesc
             if (blobProps?.LastModified != scanRequest.Timestamp)
             {
                 // we replace newline characters in log messages to avoid log injection attacks
-                double totalSeconds = blobProps is not null ? scanRequest.Timestamp.Subtract(blobProps.LastModified).TotalSeconds : 0;
+                double totalSeconds = blobProps is not null
+                    ? scanRequest.Timestamp.Subtract(blobProps.LastModified).TotalSeconds
+                    : 0;
                 _logger.LogError(
                     "Scan request timestamp != blob last modified timestamp, scan request aborted. Instance Id: {InstanceId}, DataElementId: {DataElementId}, timestamp diff: {TimeDiff} seconds",
                     scanRequest.InstanceId.Replace(Environment.NewLine, string.Empty),
                     scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty),
-                    totalSeconds);
+                    totalSeconds
+                );
                 return;
             }
 
-            var stream = await _repository.GetBlob(scanRequest.Org, scanRequest.BlobStoragePath, scanRequest.StorageAccountNumber);
+            var stream = await _repository.GetBlob(
+                scanRequest.Org,
+                scanRequest.BlobStoragePath,
+                scanRequest.StorageAccountNumber
+            );
 
             var filename = $"{scanRequest.DataElementId}.bin";
             ScanResult scanResult = await _muescheliClient.ScanStream(stream, filename);
@@ -89,21 +109,25 @@ public class DataElementService(IAppOwnerBlob repository, IMuescheliClient muesc
                 case ScanResult.ERROR:
                 case ScanResult.PARSE_ERROR:
                 case ScanResult.UNDEFINED:
-                    _logger.LogError("Scan of {DataElementId} completed with unexpected result {ScanResult}.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty), scanResult);
+                    _logger.LogError(
+                        "Scan of {DataElementId} completed with unexpected result {ScanResult}.",
+                        scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty),
+                        scanResult
+                    );
                     throw MuescheliScanResultException.Create(scanRequest.DataElementId, scanResult);
             }
 
-            FileScanStatus status = new()
-            {
-                ContentHash = string.Empty,
-                FileScanResult = fileScanResult
-            };
+            FileScanStatus status = new() { ContentHash = string.Empty, FileScanResult = fileScanResult };
 
             await _storageClient.PatchFileScanStatus(scanRequest.InstanceId, scanRequest.DataElementId, status);
         }
         catch (MuescheliHttpException e)
         {
-            _logger.LogError(e, "Scan of {DataElementId} failed with an http exception.", scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty));
+            _logger.LogError(
+                e,
+                "Scan of {DataElementId} failed with an http exception.",
+                scanRequest.DataElementId.Replace(Environment.NewLine, string.Empty)
+            );
             throw;
         }
     }

--- a/src/Altinn.FileScan/Services/PlatformKeyVaultService.cs
+++ b/src/Altinn.FileScan/Services/PlatformKeyVaultService.cs
@@ -26,13 +26,19 @@ public class PlatformKeyVaultService(IOptions<KeyVaultSettings> keyVaultSettings
     public async Task<X509Certificate2> GetCertificateAsync(string certId)
     {
         CertificateClient certificateClient = new(new Uri(_vaultUri), new DefaultAzureCredential());
-        AsyncPageable<CertificateProperties> certificatePropertiesPage = certificateClient.GetPropertiesOfCertificateVersionsAsync(certId);
+        AsyncPageable<CertificateProperties> certificatePropertiesPage =
+            certificateClient.GetPropertiesOfCertificateVersionsAsync(certId);
         await foreach (CertificateProperties certificateProperties in certificatePropertiesPage)
         {
-            if (certificateProperties.Enabled == true &&
-                (certificateProperties.ExpiresOn == null || certificateProperties.ExpiresOn >= DateTime.UtcNow))
+            if (
+                certificateProperties.Enabled == true
+                && (certificateProperties.ExpiresOn == null || certificateProperties.ExpiresOn >= DateTime.UtcNow)
+            )
             {
-                X509Certificate2 certificate = await certificateClient.DownloadCertificateAsync(certificateProperties.Name, certificateProperties.Version);
+                X509Certificate2 certificate = await certificateClient.DownloadCertificateAsync(
+                    certificateProperties.Name,
+                    certificateProperties.Version
+                );
                 return certificate;
             }
         }

--- a/src/Altinn.FileScan/Telemetry/RequestFilterProcessor.cs
+++ b/src/Altinn.FileScan/Telemetry/RequestFilterProcessor.cs
@@ -18,7 +18,7 @@ namespace Altinn.FileScan.Telemetry;
 public class RequestFilterProcessor(IHttpContextAccessor httpContextAccessor = null) : BaseProcessor<Activity>()
 {
     private const string RequestKind = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
-    
+
     /// <summary>
     /// Determine whether to skip a request
     /// </summary>
@@ -46,8 +46,14 @@ public class RequestFilterProcessor(IHttpContextAccessor httpContextAccessor = n
     /// <param name="activity">xx</param>
     public override void OnEnd(Activity activity)
     {
-        if (activity.OperationName == RequestKind && httpContextAccessor.HttpContext is not null &&
-            httpContextAccessor.HttpContext.Request.Headers.TryGetValue("X-Forwarded-For", out StringValues ipAddress))
+        if (
+            activity.OperationName == RequestKind
+            && httpContextAccessor.HttpContext is not null
+            && httpContextAccessor.HttpContext.Request.Headers.TryGetValue(
+                "X-Forwarded-For",
+                out StringValues ipAddress
+            )
+        )
         {
             activity.SetTag("ipAddress", ipAddress.FirstOrDefault());
         }
@@ -58,7 +64,7 @@ public class RequestFilterProcessor(IHttpContextAccessor httpContextAccessor = n
         return localpath switch
         {
             var path when path.TrimEnd('/').EndsWith("/health", StringComparison.OrdinalIgnoreCase) => true,
-            _ => false
+            _ => false,
         };
     }
 }

--- a/test/Altinn.FileScan.Functions.Tests/TestingServices/CertificateResolverServiceTests.cs
+++ b/test/Altinn.FileScan.Functions.Tests/TestingServices/CertificateResolverServiceTests.cs
@@ -12,8 +12,11 @@ namespace Altinn.FileScan.Functions.Tests.TestingServices;
 
 public class CertificateResolverServiceTests
 {
-    private readonly Mock<ILogger<CertificateResolverService>> _mockLogger = new Mock<ILogger<CertificateResolverService>>();
-    private readonly IOptions<CertificateResolverSettings> _certificateResolverSettings = Options.Create(new CertificateResolverSettings { CacheCertLifetimeInSeconds = 1 });
+    private readonly Mock<ILogger<CertificateResolverService>> _mockLogger =
+        new Mock<ILogger<CertificateResolverService>>();
+    private readonly IOptions<CertificateResolverSettings> _certificateResolverSettings = Options.Create(
+        new CertificateResolverSettings { CacheCertLifetimeInSeconds = 1 }
+    );
     private readonly Mock<IKeyVaultService> _mockKeyVaultService = new Mock<IKeyVaultService>();
     private readonly IOptions<KeyVaultSettings> _keyVaultSettings = Options.Create(new KeyVaultSettings());
 
@@ -24,11 +27,17 @@ public class CertificateResolverServiceTests
         string certPath = "platform-org.pfx";
         X509Certificate2 cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, null);
 
-        _mockKeyVaultService.Setup(s => s.GetCertificateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        _mockKeyVaultService
+            .Setup(s => s.GetCertificateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(cert)
             .Verifiable();
 
-        var resolverService = new CertificateResolverService(_mockLogger.Object, _certificateResolverSettings, _mockKeyVaultService.Object, _keyVaultSettings);
+        var resolverService = new CertificateResolverService(
+            _mockLogger.Object,
+            _certificateResolverSettings,
+            _mockKeyVaultService.Object,
+            _keyVaultSettings
+        );
 
         // Act
         await resolverService.GetCertificateAsync();
@@ -45,11 +54,17 @@ public class CertificateResolverServiceTests
         string certPath = "platform-org.pfx";
         X509Certificate2 cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, null);
 
-        _mockKeyVaultService.Setup(s => s.GetCertificateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        _mockKeyVaultService
+            .Setup(s => s.GetCertificateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(cert)
             .Verifiable();
 
-        var resolverService = new CertificateResolverService(_mockLogger.Object, _certificateResolverSettings, _mockKeyVaultService.Object, _keyVaultSettings);
+        var resolverService = new CertificateResolverService(
+            _mockLogger.Object,
+            _certificateResolverSettings,
+            _mockKeyVaultService.Object,
+            _keyVaultSettings
+        );
 
         // Act
         await resolverService.GetCertificateAsync();
@@ -57,6 +72,9 @@ public class CertificateResolverServiceTests
         await resolverService.GetCertificateAsync();
 
         // Assert
-        _mockKeyVaultService.Verify(s => s.GetCertificateAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
+        _mockKeyVaultService.Verify(
+            s => s.GetCertificateAsync(It.IsAny<string>(), It.IsAny<string>()),
+            Times.Exactly(2)
+        );
     }
 }

--- a/test/Altinn.FileScan.Tests/Mocks/Authentication/ConfigurationManagerStub.cs
+++ b/test/Altinn.FileScan.Tests/Mocks/Authentication/ConfigurationManagerStub.cs
@@ -17,9 +17,7 @@ public class ConfigurationManagerStub : IConfigurationManager<OpenIdConnectConfi
     /// <summary>
     /// Initializes a new instance of <see cref="ConfigurationManagerStub" />
     /// </summary>
-    public ConfigurationManagerStub()
-    {
-    }
+    public ConfigurationManagerStub() { }
 
     /// <inheritdoc />
     public async Task<OpenIdConnectConfiguration> GetConfigurationAsync(CancellationToken cancel)

--- a/test/Altinn.FileScan.Tests/Mocks/JwtTokenMock.cs
+++ b/test/Altinn.FileScan.Tests/Mocks/JwtTokenMock.cs
@@ -26,7 +26,7 @@ public static class JwtTokenMock
             Expires = DateTime.UtcNow.AddSeconds(tokenExipry.TotalSeconds),
             SigningCredentials = GetSigningCredentials(issuer),
             Audience = "altinn.no",
-            Issuer = issuer
+            Issuer = issuer,
         };
 
         SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);

--- a/test/Altinn.FileScan.Tests/TestingClients/StorageClientTests.cs
+++ b/test/Altinn.FileScan.Tests/TestingClients/StorageClientTests.cs
@@ -25,14 +25,17 @@ public class StorageClientTests
 
         Mock<IAccessToken> accessTokenMock = new Mock<IAccessToken>();
         Mock<HttpClient> httpClientMock = new Mock<HttpClient>();
-        accessTokenMock
-            .Setup(s => s.Generate())
-            .ReturnsAsync(accessToken);
+        accessTokenMock.Setup(s => s.Generate()).ReturnsAsync(accessToken);
         httpClientMock
             .Setup(s => s.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(requestContent) });
+            .ReturnsAsync(
+                new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(requestContent) }
+            );
 
-        StorageClient testService = SetupTestService(httpClient: httpClientMock.Object, accessToken: accessTokenMock.Object);
+        StorageClient testService = SetupTestService(
+            httpClient: httpClientMock.Object,
+            accessToken: accessTokenMock.Object
+        );
 
         // Act
         bool result = await testService.DataElementExists(instanceId, dataElementId);
@@ -52,14 +55,17 @@ public class StorageClientTests
 
         Mock<IAccessToken> accessTokenMock = new Mock<IAccessToken>();
         Mock<HttpClient> httpClientMock = new Mock<HttpClient>();
-        accessTokenMock
-            .Setup(s => s.Generate())
-            .ReturnsAsync(accessToken);
+        accessTokenMock.Setup(s => s.Generate()).ReturnsAsync(accessToken);
         httpClientMock
             .Setup(s => s.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(requestContent) });
+            .ReturnsAsync(
+                new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(requestContent) }
+            );
 
-        StorageClient testService = SetupTestService(httpClient: httpClientMock.Object, accessToken: accessTokenMock.Object);
+        StorageClient testService = SetupTestService(
+            httpClient: httpClientMock.Object,
+            accessToken: accessTokenMock.Object
+        );
 
         // Act
         bool result = await testService.DataElementExists(instanceId, dataElementId);
@@ -78,14 +84,15 @@ public class StorageClientTests
 
         Mock<IAccessToken> accessTokenMock = new Mock<IAccessToken>();
         Mock<HttpClient> httpClientMock = new Mock<HttpClient>();
-        accessTokenMock
-            .Setup(s => s.Generate())
-            .ReturnsAsync(accessToken);
+        accessTokenMock.Setup(s => s.Generate()).ReturnsAsync(accessToken);
         httpClientMock
             .Setup(s => s.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest });
 
-        StorageClient testService = SetupTestService(httpClient: httpClientMock.Object, accessToken: accessTokenMock.Object);
+        StorageClient testService = SetupTestService(
+            httpClient: httpClientMock.Object,
+            accessToken: accessTokenMock.Object
+        );
 
         // Act
         Task Act() => testService.DataElementExists(instanceId, dataElementId);
@@ -95,7 +102,11 @@ public class StorageClientTests
         Assert.Equal("Unexpected response from StorageClient when checking if data element exists.", exception.Message);
     }
 
-    private static StorageClient SetupTestService(HttpClient? httpClient = null, IAccessToken? accessToken = null, IOptions<PlatformSettings>? platformSettings = null)
+    private static StorageClient SetupTestService(
+        HttpClient? httpClient = null,
+        IAccessToken? accessToken = null,
+        IOptions<PlatformSettings>? platformSettings = null
+    )
     {
         httpClient ??= new Mock<HttpClient>().Object;
         accessToken ??= new Mock<IAccessToken>().Object;

--- a/test/Altinn.FileScan.Tests/TestingControllers/DataElementControllerTests.cs
+++ b/test/Altinn.FileScan.Tests/TestingControllers/DataElementControllerTests.cs
@@ -29,21 +29,23 @@ namespace Altinn.FileScan.Tests.TestingControllers;
 /// Initializes a new instance of the <see cref="DataElementControllerTests"/> class with the given <see cref="WebApplicationFactory{DataElementController}"/>.
 /// </remarks>
 /// <param name="factory">The <see cref="WebApplicationFactory{TPushController}"/> to use when setting up the test server.</param>
-public class DataElementControllerTests(WebApplicationFactory<DataElementController> factory) : IClassFixture<WebApplicationFactory<DataElementController>>
+public class DataElementControllerTests(WebApplicationFactory<DataElementController> factory)
+    : IClassFixture<WebApplicationFactory<DataElementController>>
 {
     private const string BasePath = "/filescan/api/v1";
 
-    private readonly string serializedDataElement = "{" +
-            "\"id\": \"11f7c994-6681-47a1-9626-fcf6c27308a5\"," +
-            "\"instanceGuid\": \"649388f0-a2c0-4774-bd11-c870223ed819\"," +
-            "\"dataType\": \"default\"," +
-            "\"contentType\": \"text/plain; charset=utf-8\"," +
-            "\"blobStoragePath\": \"tdd/endring-av-navn/649388f0-a2c0-4774-bd11-c870223ed819/data/11f7c994-6681-47a1-9626-fcf6c27308a5\"," +
-            "\"size\": 19," +
-            "\"locked\": false," +
-            "\"created\": \"2020-05-11T17:09:28.4621953Z\"," +
-            "\"lastChanged\": \"2020-05-11T17:09:28.4621953Z\"" +
-            "}";
+    private readonly string serializedDataElement =
+        "{"
+        + "\"id\": \"11f7c994-6681-47a1-9626-fcf6c27308a5\","
+        + "\"instanceGuid\": \"649388f0-a2c0-4774-bd11-c870223ed819\","
+        + "\"dataType\": \"default\","
+        + "\"contentType\": \"text/plain; charset=utf-8\","
+        + "\"blobStoragePath\": \"tdd/endring-av-navn/649388f0-a2c0-4774-bd11-c870223ed819/data/11f7c994-6681-47a1-9626-fcf6c27308a5\","
+        + "\"size\": 19,"
+        + "\"locked\": false,"
+        + "\"created\": \"2020-05-11T17:09:28.4621953Z\","
+        + "\"lastChanged\": \"2020-05-11T17:09:28.4621953Z\""
+        + "}";
 
     /// <summary>
     /// Scenario:
@@ -59,14 +61,13 @@ public class DataElementControllerTests(WebApplicationFactory<DataElementControl
         // Arrange
         string requestUri = $"{BasePath}/dataelement";
         var dataElementMock = new Mock<IDataElement>();
-        dataElementMock
-            .Setup(de => de.Scan(It.IsAny<DataElementScanRequest>()));
+        dataElementMock.Setup(de => de.Scan(It.IsAny<DataElementScanRequest>()));
 
         HttpClient client = GetTestClient(dataElementMock.Object);
 
         HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri)
         {
-            Content = new StringContent(serializedDataElement, Encoding.UTF8, "application/json")
+            Content = new StringContent(serializedDataElement, Encoding.UTF8, "application/json"),
         };
 
         httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "file-scan"));
@@ -95,7 +96,7 @@ public class DataElementControllerTests(WebApplicationFactory<DataElementControl
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
         HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri)
         {
-            Content = new StringContent(serializedDataElement, Encoding.UTF8, "application/json")
+            Content = new StringContent(serializedDataElement, Encoding.UTF8, "application/json"),
         };
 
         // Act
@@ -121,7 +122,7 @@ public class DataElementControllerTests(WebApplicationFactory<DataElementControl
         HttpClient client = GetTestClient();
         HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri)
         {
-            Content = new StringContent(serializedDataElement, Encoding.UTF8, "application/json")
+            Content = new StringContent(serializedDataElement, Encoding.UTF8, "application/json"),
         };
 
         // Act
@@ -135,17 +136,19 @@ public class DataElementControllerTests(WebApplicationFactory<DataElementControl
     {
         dataElementMock ??= new Mock<IDataElement>().Object;
 
-        HttpClient client = factory.WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureTestServices(services =>
+        HttpClient client = factory
+            .WithWebHostBuilder(builder =>
             {
-                // Set up mock authentication so that not well known endpoint is used
-                services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
-                services.AddSingleton<IPublicSigningKeyProvider, PublicSigningKeyProviderMock>();
+                builder.ConfigureTestServices(services =>
+                {
+                    // Set up mock authentication so that not well known endpoint is used
+                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                    services.AddSingleton<IPublicSigningKeyProvider, PublicSigningKeyProviderMock>();
 
-                services.AddSingleton(dataElementMock);
-            });
-        }).CreateClient();
+                    services.AddSingleton(dataElementMock);
+                });
+            })
+            .CreateClient();
 
         return client;
     }

--- a/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
+++ b/test/Altinn.FileScan.Tests/TestingServices/DataElementServiceTests.cs
@@ -32,7 +32,7 @@ public class DataElementServiceTests
         InstanceId = "instanceId",
         Timestamp = _requestTimestamp,
         Filename = "attachment.pdf",
-        Org = "ttd"
+        Org = "ttd",
     };
 
     [Fact]
@@ -42,23 +42,36 @@ public class DataElementServiceTests
         Mock<IAppOwnerBlob> blobMock = new();
         blobMock
             .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
-            .ReturnsAsync(new BlobPropertyModel
-            {
-                LastModified = _matchingTimestamp
-            });
+            .ReturnsAsync(new BlobPropertyModel { LastModified = _matchingTimestamp });
         blobMock
-            .Setup(b => b.GetBlob(It.Is<string>(s => s == "ttd"), It.Is<string>(s => s == "blobstoragePath/org/attachment.pdf"), null))
+            .Setup(b =>
+                b.GetBlob(
+                    It.Is<string>(s => s == "ttd"),
+                    It.Is<string>(s => s == "blobstoragePath/org/attachment.pdf"),
+                    null
+                )
+            )
             .ReturnsAsync((Stream)null);
 
         Mock<IMuescheliClient> muescheliClientMock = new();
-        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
+        muescheliClientMock
+            .Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
             .ReturnsAsync(ScanResult.OK);
 
         Mock<IStorageClient> storageClientMock = new();
-        storageClientMock
-            .Setup(s => s.PatchFileScanStatus(It.Is<string>(s => s == "instanceId"), It.Is<string>(s => s == "dataElementId"), It.Is<FileScanStatus>(f => f.FileScanResult == FileScanResult.Clean)));
+        storageClientMock.Setup(s =>
+            s.PatchFileScanStatus(
+                It.Is<string>(s => s == "instanceId"),
+                It.Is<string>(s => s == "dataElementId"),
+                It.Is<FileScanStatus>(f => f.FileScanResult == FileScanResult.Clean)
+            )
+        );
 
-        DataElementService sut = SetUpTestService(blobMock.Object, muescheliClientMock.Object, storageClientMock.Object);
+        DataElementService sut = SetUpTestService(
+            blobMock.Object,
+            muescheliClientMock.Object,
+            storageClientMock.Object
+        );
 
         // Act
         await sut.Scan(_defaultDataElementScanRequest);
@@ -74,7 +87,8 @@ public class DataElementServiceTests
     {
         // Arrange
         Mock<IMuescheliClient> muescheliClientMock = new();
-        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.bin")))
+        muescheliClientMock
+            .Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.bin")))
             .ReturnsAsync(ScanResult.OK);
 
         DataElementService sut = SetUpTestService(muescheliClient: muescheliClientMock.Object);
@@ -85,7 +99,7 @@ public class DataElementServiceTests
             DataElementId = "dataElementId",
             Timestamp = _requestTimestamp,
             InstanceId = "instanceId",
-            Org = "ttd"
+            Org = "ttd",
         };
 
         // Act
@@ -103,20 +117,20 @@ public class DataElementServiceTests
         blobMock
             .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
             .ReturnsAsync(new BlobPropertyModel { LastModified = _nonMatchingTimestamp });
-        blobMock
-            .Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>(), null))
-            .ReturnsAsync((Stream)null);
+        blobMock.Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>(), null)).ReturnsAsync((Stream)null);
 
         Mock<ILogger<DataElementService>> loggerMock = new Mock<ILogger<DataElementService>>();
 
         Mock<IMuescheliClient> muescheliClientMock = new();
-        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.txt")))
+        muescheliClientMock
+            .Setup(m => m.ScanStream(It.IsAny<Stream>(), It.Is<string>(s => s == "dataElementId.txt")))
             .ReturnsAsync(ScanResult.OK);
 
         DataElementService sut = SetUpTestService(
             appOwnerBlob: blobMock.Object,
             muescheliClient: muescheliClientMock.Object,
-            logger: loggerMock.Object);
+            logger: loggerMock.Object
+        );
 
         var input = new DataElementScanRequest
         {
@@ -124,32 +138,52 @@ public class DataElementServiceTests
             DataElementId = "dataElementId",
             Timestamp = _requestTimestamp,
             InstanceId = "instanceId",
-            Org = "ttd"
+            Org = "ttd",
         };
 
         // Act
         await sut.Scan(input);
 
         // Assert
-        loggerMock.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+        loggerMock.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()
+                ),
+            Times.Once
+        );
         muescheliClientMock.Verify(x => x.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()), Times.Never);
     }
 
     [Theory]
     [InlineData(ScanResult.OK, FileScanResult.Clean)]
     [InlineData(ScanResult.FOUND, FileScanResult.Infected)]
-    public async Task Scan_DeterminateScanResult_MappedCorrectlyToFileSCcanResult(ScanResult scanResult, FileScanResult expectedFileScanResult)
+    public async Task Scan_DeterminateScanResult_MappedCorrectlyToFileSCcanResult(
+        ScanResult scanResult,
+        FileScanResult expectedFileScanResult
+    )
     {
         // Arrange
         Mock<IMuescheliClient> muescheliClientMock = new();
-        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
-            .ReturnsAsync(scanResult);
+        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>())).ReturnsAsync(scanResult);
 
         Mock<IStorageClient> storageClientMock = new();
-        storageClientMock
-            .Setup(s => s.PatchFileScanStatus(It.IsAny<string>(), It.IsAny<string>(), It.Is<FileScanStatus>(f => f.FileScanResult == expectedFileScanResult)));
+        storageClientMock.Setup(s =>
+            s.PatchFileScanStatus(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.Is<FileScanStatus>(f => f.FileScanResult == expectedFileScanResult)
+            )
+        );
 
-        DataElementService sut = SetUpTestService(muescheliClient: muescheliClientMock.Object, storageClient: storageClientMock.Object);
+        DataElementService sut = SetUpTestService(
+            muescheliClient: muescheliClientMock.Object,
+            storageClient: storageClientMock.Object
+        );
 
         // Act
         await sut.Scan(_defaultDataElementScanRequest);
@@ -167,8 +201,7 @@ public class DataElementServiceTests
     {
         // Arrange
         Mock<IMuescheliClient> muescheliClientMock = new();
-        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
-            .ReturnsAsync(scanResult);
+        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>())).ReturnsAsync(scanResult);
 
         DataElementService sut = SetUpTestService(muescheliClient: muescheliClientMock.Object);
 
@@ -177,7 +210,10 @@ public class DataElementServiceTests
 
         // Assert
         MuescheliScanResultException exception = await Assert.ThrowsAsync<MuescheliScanResultException>(Act);
-        Assert.Equal($"Muescheli scan returned result code `{scanResult}` for data element with id dataElementId", exception.Message);
+        Assert.Equal(
+            $"Muescheli scan returned result code `{scanResult}` for data element with id dataElementId",
+            exception.Message
+        );
     }
 
     [Fact]
@@ -185,8 +221,14 @@ public class DataElementServiceTests
     {
         // Arrange
         Mock<IMuescheliClient> muescheliClientMock = new();
-        muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
-            .ThrowsAsync(await MuescheliHttpException.CreateAsync(HttpStatusCode.NotFound, new HttpResponseMessage(HttpStatusCode.NotFound)));
+        muescheliClientMock
+            .Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
+            .ThrowsAsync(
+                await MuescheliHttpException.CreateAsync(
+                    HttpStatusCode.NotFound,
+                    new HttpResponseMessage(HttpStatusCode.NotFound)
+                )
+            );
 
         DataElementService sut = SetUpTestService(muescheliClient: muescheliClientMock.Object);
 
@@ -207,20 +249,29 @@ public class DataElementServiceTests
         repository
             .Setup(r => r.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
             .ThrowsAsync(new RequestFailedException(string.Empty));
-        storageClient
-            .Setup(s => s.DataElementExists(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(false);
+        storageClient.Setup(s => s.DataElementExists(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(false);
 
         DataElementService sut = SetUpTestService(
             appOwnerBlob: repository.Object,
             storageClient: storageClient.Object,
-            logger: loggerMock.Object);
+            logger: loggerMock.Object
+        );
 
         // Act
         await sut.Scan(_defaultDataElementScanRequest);
 
         // Assert
-        loggerMock.Verify(x => x.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Exactly(2));
+        loggerMock.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()
+                ),
+            Times.Exactly(2)
+        );
         storageClient.Verify(x => x.DataElementExists(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
     }
 
@@ -234,23 +285,45 @@ public class DataElementServiceTests
         repository
             .Setup(r => r.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
             .ThrowsAsync(new RequestFailedException(string.Empty));
-        storageClient
-            .Setup(s => s.DataElementExists(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(true);
+        storageClient.Setup(s => s.DataElementExists(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
 
         DataElementService sut = SetUpTestService(
             appOwnerBlob: repository.Object,
             storageClient: storageClient.Object,
-            logger: loggerMock.Object);
+            logger: loggerMock.Object
+        );
 
         // Act
         Task Act() => sut.Scan(_defaultDataElementScanRequest);
 
         // Assert
         RequestFailedException exception = await Assert.ThrowsAsync<RequestFailedException>(Act);
-        Assert.Equal($"DataElement {_defaultDataElementScanRequest.DataElementId} found and blob does not exist", exception.Message);
-        loggerMock.Verify(x => x.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<RequestFailedException>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
-        loggerMock.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<RequestFailedException>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+        Assert.Equal(
+            $"DataElement {_defaultDataElementScanRequest.DataElementId} found and blob does not exist",
+            exception.Message
+        );
+        loggerMock.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<RequestFailedException>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()
+                ),
+            Times.Once
+        );
+        loggerMock.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<RequestFailedException>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()
+                ),
+            Times.Once
+        );
         storageClient.Verify(x => x.DataElementExists(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
     }
 
@@ -258,20 +331,16 @@ public class DataElementServiceTests
         IAppOwnerBlob appOwnerBlob = null,
         IMuescheliClient muescheliClient = null,
         IStorageClient storageClient = null,
-        ILogger<DataElementService> logger = null)
+        ILogger<DataElementService> logger = null
+    )
     {
         if (appOwnerBlob is null)
         {
             Mock<IAppOwnerBlob> blobMock = new();
             blobMock
                 .Setup(b => b.GetBlobProperties(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
-                .ReturnsAsync(new BlobPropertyModel
-                {
-                    LastModified = _matchingTimestamp
-                });
-            blobMock
-                .Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>(), null))
-                .ReturnsAsync((Stream)null);
+                .ReturnsAsync(new BlobPropertyModel { LastModified = _matchingTimestamp });
+            blobMock.Setup(b => b.GetBlob(It.IsAny<string>(), It.IsAny<string>(), null)).ReturnsAsync((Stream)null);
 
             appOwnerBlob = blobMock.Object;
         }
@@ -279,7 +348,8 @@ public class DataElementServiceTests
         if (muescheliClient is null)
         {
             Mock<IMuescheliClient> muescheliClientMock = new();
-            muescheliClientMock.Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
+            muescheliClientMock
+                .Setup(m => m.ScanStream(It.IsAny<Stream>(), It.IsAny<string>()))
                 .ReturnsAsync(ScanResult.OK);
 
             muescheliClient = muescheliClientMock.Object;
@@ -288,8 +358,9 @@ public class DataElementServiceTests
         if (storageClient is null)
         {
             Mock<IStorageClient> storageClientMock = new();
-            storageClientMock
-                .Setup(s => s.PatchFileScanStatus(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<FileScanStatus>()));
+            storageClientMock.Setup(s =>
+                s.PatchFileScanStatus(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<FileScanStatus>())
+            );
 
             storageClient = storageClientMock.Object;
         }

--- a/test/Altinn.FileScan.Tests/Utils/PrincipalUtil.cs
+++ b/test/Altinn.FileScan.Tests/Utils/PrincipalUtil.cs
@@ -21,7 +21,12 @@ public static class PrincipalUtil
             new Claim(AltinnCoreClaimTypes.UserName, "UserOne", ClaimValueTypes.String, issuer),
             new Claim(AltinnCoreClaimTypes.PartyID, userId.ToString(), ClaimValueTypes.Integer32, issuer),
             new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "Mock", ClaimValueTypes.String, issuer),
-            new Claim(AltinnCoreClaimTypes.AuthenticationLevel, authenticationLevel.ToString(), ClaimValueTypes.Integer32, issuer)
+            new Claim(
+                AltinnCoreClaimTypes.AuthenticationLevel,
+                authenticationLevel.ToString(),
+                ClaimValueTypes.Integer32,
+                issuer
+            ),
         };
 
         if (scope != null)
@@ -46,10 +51,7 @@ public static class PrincipalUtil
 
     public static string GetAccessToken(string issuer, string app)
     {
-        List<Claim> claims = new()
-        {
-            new Claim(AccessTokenClaimTypes.App, app, ClaimValueTypes.String, issuer)
-        };
+        List<Claim> claims = new() { new Claim(AccessTokenClaimTypes.App, app, ClaimValueTypes.String, issuer) };
 
         ClaimsIdentity identity = new("mock");
         identity.AddClaims(claims);


### PR DESCRIPTION
## Description

Adopts [CSharpier](https://csharpier.com/) for code formatting, matching the setup used in [altinn-studio](https://github.com/Altinn/altinn-studio) / [app-lib-dotnet](https://github.com/Altinn/app-lib-dotnet). Same approach as the equivalent altinn-receipt PR.

> [!NOTE]
> **Stacked on #428** (StyleCop removal). This PR is based on the `chore/remove-stylecop` branch, so the diff shows only the CSharpier changes. Merge #428 first, then this — or retarget this PR to `main` once #428 lands. CSharpier's formatting conflicts with several StyleCop `error`-level rules, so the two must not be in the tree together.

## Changes

**Tooling & config**
- `.config/dotnet-tools.json` — pins `csharpier` 1.2.6 as a local dotnet tool (`dotnet tool restore`)
- `.csharpierrc.yaml` — `printWidth: 120`, 4-space indent, `endOfLine: auto`
- `.csharpierignore` — excludes `bin/`, `obj/`, `.git/`, and generated/project files
- `Directory.Build.props` — adds `CSharpier.MsBuild` so formatting runs automatically on every build
- `.github/workflows/verify-formatting.yml` — CI job running `dotnet csharpier check .` on PRs
- `.git-blame-ignore-revs` — excludes the bulk-format commit from `git blame`

**Formatting**
- `style: format codebase with csharpier` — applied csharpier across the solution (formatting-only, no behavioral changes; isolated in its own commit and listed in `.git-blame-ignore-revs`)

## Adaptations for this repo

- **Inline package version** — no central package management here, so `CSharpier.MsBuild` is pinned inline (`1.2.6`)
- **dotnet `10.0.x` / `ubuntu-latest`** in the formatting workflow, matching the existing `build-and-analyze.yml`
- **No `minver`** — not used in this repo
- **No `.vscode/settings.json`** — `CSharpier.MsBuild` covers format-on-build regardless of editor
- Verified `CSharpier.MsBuild` builds cleanly through the Azure Functions generated `WorkerExtensions` project (no guard needed)

## Verification

- `dotnet csharpier check .` — clean (54 files)
- `dotnet build Altinn.FileScan.sln` — succeeds (only the pre-existing `CS9113` warning)
- `dotnet test Altinn.FileScan.sln` — 19 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)